### PR TITLE
FIX SCP-1707: Fixed problems in JSON uniqueItems normalization

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -26,6 +26,10 @@
              , { report
                , {eunit_surefire, [{dir, "."}]}
                }]}.
+{ project_plugins
+, [ {rebar3_lint, "0.4.0"}
+, {rebar3_proper, "0.12.1"}
+]}.
 { deps
 , [ { jsx
     , ".*"
@@ -39,6 +43,7 @@
       , {tag, "0.2.1-r15-compat"}
       }
     }
+  , { proper, "1.4.0"}
   ]}.
 {escript_name, "bin/jesse"}.
 {escript_emu_args, "%%! -noinput\n"}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
 %%-*- mode: erlang -*-
+{profiles, [{test, [{deps, [{ proper, ">= 0.0.0"}]}]}]}.
 {lib_dirs,[ ".."
           , "deps"
           ]}.
@@ -43,7 +44,6 @@
       , {tag, "0.2.1-r15-compat"}
       }
     }
-  , { proper, "1.4.0"}
   ]}.
 {escript_name, "bin/jesse"}.
 {escript_emu_args, "%%! -noinput\n"}.

--- a/src/jesse_lib.erl
+++ b/src/jesse_lib.erl
@@ -29,8 +29,8 @@
         , is_json_object/1
         , is_json_object_empty/1
         , is_null/1
-        , normalize_and_sort/2
-        , is_equal/3
+        , normalize_and_sort/1
+        , is_equal/2
         ]).
 
 %% Includes
@@ -115,20 +115,20 @@ is_json_object_empty(_) ->
 %% lists with the same elements but in different order.  Lists for
 %% which order is relevant, e.g. JSON arrays, keep their original
 %% order and will be considered diffferent if the order is different.
--spec normalize_and_sort(Value :: any(), DraftVersion :: 3 | 4) -> any().
-normalize_and_sort(Value, DraftVersion) ->
-  normalize_and_sort_check_object(Value, DraftVersion).
+-spec normalize_and_sort(Value :: any()) -> any().
+normalize_and_sort(Value) ->
+  normalize_and_sort_check_object(Value).
 
 %% This code would look much better if we could use normalize_and_sort_check_object
 %% as a guard expression, but that is not possible.  So we need to check
 %% in every recurssion step, first if the Value is a JSON object with
 %% properties, and in that case call a different function for this values.
 %% @private
--spec normalize_and_sort_check_object(Value :: any(), DraftVersion :: 3 | 4) -> any().
-normalize_and_sort_check_object(Value, DraftVersion) ->
+-spec normalize_and_sort_check_object(Value :: any()) -> any().
+normalize_and_sort_check_object(Value) ->
   case jesse_lib:is_json_object(Value) of
-    true -> normalize_and_sort_object(Value, DraftVersion);
-    false -> normalize_and_sort_non_object(Value, DraftVersion)
+    true -> normalize_and_sort_object(Value);
+    false -> normalize_and_sort_non_object(Value)
   end.
 
 %% This function covers the recursion over:
@@ -139,19 +139,15 @@ normalize_and_sort_check_object(Value, DraftVersion) ->
 %%   in the list.
 %% - Basic JSON types. In that case, we just return the value.
 %% @private
--spec normalize_and_sort_non_object(Value :: any(), DraftVersion :: 3 | 4) -> any().
-normalize_and_sort_non_object({Key, Val}, DraftVersion) ->
-  {Key, normalize_and_sort_check_object(Val, DraftVersion)};
-normalize_and_sort_non_object(Value, DraftVersion) when is_list(Value) ->
-  [normalize_and_sort_check_object(X, DraftVersion) || X <- Value];
-normalize_and_sort_non_object(Value, DraftVersion) ->
-  case DraftVersion of
-    3 -> Value;
-    4 -> case Value of
-           Number when is_number(Number) -> float(Number);
-           _ -> Value
-         end
-  end.
+-spec normalize_and_sort_non_object(Value :: any()) -> any().
+normalize_and_sort_non_object({Key, Val}) ->
+  {Key, normalize_and_sort_check_object(Val)};
+normalize_and_sort_non_object(Value) when is_list(Value) ->
+  [normalize_and_sort_check_object(X) || X <- Value];
+normalize_and_sort_non_object(Value) when is_number(Value) ->
+  float(Value);
+normalize_and_sort_non_object(Value) ->
+  Value.
 
 %% This function runs the normalization/ordering over the properties
 %% of a JSON object. If the object is not formatted as a list (e.g. a
@@ -159,11 +155,11 @@ normalize_and_sort_non_object(Value, DraftVersion) ->
 %% order so that its original odering is not relevant, and we run
 %% the normalization/ordering through each of the properties.
 %% @private
--spec normalize_and_sort_object(Value :: any(), DraftVersion :: 3 | 4) -> any().
-normalize_and_sort_object(Value, DraftVersion) when is_list(Value) ->
-  {struct, lists:sort([normalize_and_sort_check_object(X, DraftVersion) || X <- Value])};
-normalize_and_sort_object(Value, DraftVersion) ->
-  normalize_and_sort_object(jesse_json_path:unwrap_value(Value), DraftVersion).
+-spec normalize_and_sort_object(Value :: any()) -> any().
+normalize_and_sort_object(Value) when is_list(Value) ->
+  {struct, lists:sort([normalize_and_sort_check_object(X) || X <- Value])};
+normalize_and_sort_object(Value) ->
+  normalize_and_sort_object(jesse_json_path:unwrap_value(Value)).
 
 %%=============================================================================
 %% @doc Returns `true' if given values (instance) are equal, otherwise `false'
@@ -184,49 +180,46 @@ normalize_and_sort_object(Value, DraftVersion) ->
 %%       in the object is equal to the corresponding property in the other
 %%       object.</li>
 %% </ul>
-is_equal(Value1, Value2, DraftVersion) ->
+-spec is_equal(Value1 :: any(), Value2 :: any()) -> boolean().
+is_equal(Value1, Value2) ->
   case jesse_lib:is_json_object(Value1)
     andalso jesse_lib:is_json_object(Value2) of
-    true  -> compare_objects(Value1, Value2, DraftVersion);
+    true  -> compare_objects(Value1, Value2);
     false -> case is_list(Value1) andalso is_list(Value2) of
-               true  -> compare_lists(Value1, Value2, DraftVersion);
-               false -> case DraftVersion of
-                          3 -> Value1 =:= Value2;
-                          4 -> Value1 == Value2
-                        end
+               true  -> compare_lists(Value1, Value2);
+               false -> Value1 == Value2
              end
   end.
 
 %% @private
-compare_lists(Value1, Value2, DraftVersion) ->
+compare_lists(Value1, Value2) ->
   case length(Value1) =:= length(Value2) of
-    true  -> compare_elements(Value1, Value2, DraftVersion);
+    true  -> compare_elements(Value1, Value2);
     false -> false
   end.
 
 %% @private
-compare_elements(Value1, Value2, DraftVersion) ->
+compare_elements(Value1, Value2) ->
   lists:all( fun({Element1, Element2}) ->
-                 is_equal(Element1, Element2, DraftVersion)
+                 is_equal(Element1, Element2)
              end
            , lists:zip(Value1, Value2)
            ).
 
 %% @private
-compare_objects(Value1, Value2, DraftVersion) ->
+compare_objects(Value1, Value2) ->
   case length(unwrap(Value1)) =:= length(unwrap(Value2)) of
-    true  -> compare_properties(Value1, Value2, DraftVersion);
+    true  -> compare_properties(Value1, Value2);
     false -> false
   end.
 
 %% @private
-compare_properties(Value1, Value2, DraftVersion) ->
+compare_properties(Value1, Value2) ->
   lists:all( fun({PropertyName1, PropertyValue1}) ->
                  case get_value(PropertyName1, Value2) of
                    ?not_found     -> false;
                    PropertyValue2 -> is_equal(PropertyValue1,
-                                              PropertyValue2,
-                                              DraftVersion)
+                                              PropertyValue2)
                  end
              end
            , unwrap(Value1)

--- a/src/jesse_schema_validator.hrl
+++ b/src/jesse_schema_validator.hrl
@@ -28,6 +28,17 @@
 -define(IF_MAPS(Exp), Exp).
 -endif.
 
+%% Use optimization for sets if available
+-ifdef(OTP_RELEASE).
+  -if(?OTP_RELEASE >= 24).
+  %% OTP 24 or higher
+    -define(SET_FROM_LIST(List), sets:from_list(List, [{version, 2}])).
+  -else.
+  %% OTP 23 or lower.
+    -define(SET_FROM_LIST(List), sets:from_list(List)).
+  -endif.
+-endif.
+
 %% Constant definitions for Json schema keywords
 -define(SCHEMA,               <<"$schema">>).
 -define(TYPE,                 <<"type">>).

--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -776,8 +776,8 @@ check_unique_items(Value, true, State) ->
 %% lists for which order is not relevant are sorted (objects are normalized).
 %% If the first efficient check fails, then we search for the items that are
 %% duplicated with a less efficient check (that will very seldom be executed).
-    NormalizedValue = jesse_lib:normalize_and_sort(Value),
-    NoDuplicates = sets:from_list(NormalizedValue, [{version, 2}]),
+    NormalizedValue = jesse_lib:normalize_and_sort(Value, 3),
+    NoDuplicates = ?SET_FROM_LIST(NormalizedValue),
     case sets:size(NoDuplicates) == length(Value) of
       true -> State;
       false ->
@@ -785,7 +785,9 @@ check_unique_items(Value, true, State) ->
                          ok;
                         (Item, RestItems) ->
                          lists:foreach( fun(ItemFromRest) ->
-                                            case is_equal(Item, ItemFromRest) of
+                                            case jesse_lib:is_equal(Item,
+                                                                    ItemFromRest,
+                                                                    3) of
                                               true  ->
                                                 throw({?not_unique, Item});
                                               false -> ok
@@ -853,7 +855,7 @@ check_max_length(Value, MaxLength, State) ->
 %% @private
 check_enum(Value, Enum, State) ->
   IsValid = lists:any( fun(ExpectedValue) ->
-                           is_equal(Value, ExpectedValue)
+                           jesse_lib:is_equal(Value, ExpectedValue, 3)
                        end
                      , Enum
                      ),
@@ -960,69 +962,6 @@ resolve_ref(Reference, State) ->
 
 undo_resolve_ref(State, OriginalState) ->
   jesse_state:undo_resolve_ref(State, OriginalState).
-
-%%=============================================================================
-%% @doc Returns `true' if given values (instance) are equal, otherwise `false'
-%% is returned.
-%%
-%% Two instance are consider equal if they are both of the same type
-%% and:
-%% <ul>
-%%   <li>are null; or</li>
-%%
-%%   <li>are booleans/numbers/strings and have the same value; or</li>
-%%
-%%   <li>are arrays, contains the same number of items, and each item in
-%%       the array is equal to the corresponding item in the other array;
-%%       or</li>
-%%
-%%   <li>are objects, contains the same property names, and each property
-%%       in the object is equal to the corresponding property in the other
-%%       object.</li>
-%% </ul>
-%% @private
-is_equal(Value1, Value2) ->
-  case jesse_lib:is_json_object(Value1)
-    andalso jesse_lib:is_json_object(Value2) of
-    true  -> compare_objects(Value1, Value2);
-    false -> case is_list(Value1) andalso is_list(Value2) of
-               true  -> compare_lists(Value1, Value2);
-               false -> Value1 =:= Value2
-             end
-  end.
-
-%% @private
-compare_lists(Value1, Value2) ->
-  case length(Value1) =:= length(Value2) of
-    true  -> compare_elements(Value1, Value2);
-    false -> false
-  end.
-
-%% @private
-compare_elements(Value1, Value2) ->
-  lists:all( fun({Element1, Element2}) ->
-                 is_equal(Element1, Element2)
-             end
-           , lists:zip(Value1, Value2)
-           ).
-
-%% @private
-compare_objects(Value1, Value2) ->
-  case length(unwrap(Value1)) =:= length(unwrap(Value2)) of
-    true  -> compare_properties(Value1, Value2);
-    false -> false
-  end.
-
-%% @private
-compare_properties(Value1, Value2) ->
-  lists:all( fun({PropertyName1, PropertyValue1}) ->
-                 case get_value(PropertyName1, Value2) of
-                   ?not_found     -> false;
-                   PropertyValue2 -> is_equal(PropertyValue1, PropertyValue2)
-                 end
-             end
-           , unwrap(Value1)
-           ).
 
 %%=============================================================================
 %% Wrappers

--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -776,7 +776,7 @@ check_unique_items(Value, true, State) ->
 %% lists for which order is not relevant are sorted (objects are normalized).
 %% If the first efficient check fails, then we search for the items that are
 %% duplicated with a less efficient check (that will very seldom be executed).
-    NormalizedValue = jesse_lib:normalize_and_sort(Value, 3),
+    NormalizedValue = jesse_lib:normalize_and_sort(Value),
     NoDuplicates = ?SET_FROM_LIST(NormalizedValue),
     case sets:size(NoDuplicates) == length(Value) of
       true -> State;
@@ -786,8 +786,7 @@ check_unique_items(Value, true, State) ->
                         (Item, RestItems) ->
                          lists:foreach( fun(ItemFromRest) ->
                                             case jesse_lib:is_equal(Item,
-                                                                    ItemFromRest,
-                                                                    3) of
+                                                                    ItemFromRest) of
                                               true  ->
                                                 throw({?not_unique, Item});
                                               false -> ok
@@ -855,7 +854,7 @@ check_max_length(Value, MaxLength, State) ->
 %% @private
 check_enum(Value, Enum, State) ->
   IsValid = lists:any( fun(ExpectedValue) ->
-                           jesse_lib:is_equal(Value, ExpectedValue, 3)
+                           jesse_lib:is_equal(Value, ExpectedValue)
                        end
                      , Enum
                      ),

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -854,7 +854,7 @@ check_unique_items(Value, true, State) ->
 %% lists for which order is not relevant are sorted (objects are normalized).
 %% If the first efficient check fails, then we search for the items that are
 %% duplicated with a less efficient check (that will very seldom be executed).
-    NormalizedValue = jesse_lib:normalize_and_sort(Value, 4),
+    NormalizedValue = jesse_lib:normalize_and_sort(Value),
     NoDuplicates = ?SET_FROM_LIST(NormalizedValue),
     case sets:size(NoDuplicates) == length(Value) of
       true -> State;
@@ -864,8 +864,7 @@ check_unique_items(Value, true, State) ->
                       (Item, RestItems) ->
                        lists:foreach( fun(ItemFromRest) ->
                                           case jesse_lib:is_equal(Item,
-                                                                 ItemFromRest,
-                                                                 4) of
+                                                                 ItemFromRest) of
                                             true  ->
                                               throw({?not_unique, Item});
                                             false -> ok
@@ -971,7 +970,7 @@ check_max_length(Value, MaxLength, State) ->
 %% @private
 check_enum(Value, Enum, State) ->
   IsValid = lists:any( fun(ExpectedValue) ->
-                           jesse_lib:is_equal(Value, ExpectedValue, 4)
+                           jesse_lib:is_equal(Value, ExpectedValue)
                        end
                      , Enum
                      ),

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -854,8 +854,8 @@ check_unique_items(Value, true, State) ->
 %% lists for which order is not relevant are sorted (objects are normalized).
 %% If the first efficient check fails, then we search for the items that are
 %% duplicated with a less efficient check (that will very seldom be executed).
-    NormalizedValue = jesse_lib:normalize_and_sort(Value),
-    NoDuplicates = sets:from_list(NormalizedValue, [{version, 2}]),
+    NormalizedValue = jesse_lib:normalize_and_sort(Value, 4),
+    NoDuplicates = ?SET_FROM_LIST(NormalizedValue),
     case sets:size(NoDuplicates) == length(Value) of
       true -> State;
       false ->
@@ -863,7 +863,9 @@ check_unique_items(Value, true, State) ->
                        ok;
                       (Item, RestItems) ->
                        lists:foreach( fun(ItemFromRest) ->
-                                          case is_equal(Item, ItemFromRest) of
+                                          case jesse_lib:is_equal(Item,
+                                                                 ItemFromRest,
+                                                                 4) of
                                             true  ->
                                               throw({?not_unique, Item});
                                             false -> ok
@@ -969,7 +971,7 @@ check_max_length(Value, MaxLength, State) ->
 %% @private
 check_enum(Value, Enum, State) ->
   IsValid = lists:any( fun(ExpectedValue) ->
-                           is_equal(Value, ExpectedValue)
+                           jesse_lib:is_equal(Value, ExpectedValue, 4)
                        end
                      , Enum
                      ),
@@ -1282,69 +1284,6 @@ resolve_ref(Reference, State) ->
 
 undo_resolve_ref(State, OriginalState) ->
   jesse_state:undo_resolve_ref(State, OriginalState).
-
-%%=============================================================================
-%% @doc Returns `true' if given values (instance) are equal, otherwise `false'
-%% is returned.
-%%
-%% Two instance are consider equal if they are both of the same type
-%% and:
-%% <ul>
-%%   <li>are null; or</li>
-%%
-%%   <li>are booleans/numbers/strings and have the same value; or</li>
-%%
-%%   <li>are arrays, contains the same number of items, and each item in
-%%       the array is equal to the corresponding item in the other array;
-%%       or</li>
-%%
-%%   <li>are objects, contains the same property names, and each property
-%%       in the object is equal to the corresponding property in the other
-%%       object.</li>
-%% </ul>
-%% @private
-is_equal(Value1, Value2) ->
-  case jesse_lib:is_json_object(Value1)
-    andalso jesse_lib:is_json_object(Value2) of
-    true  -> compare_objects(Value1, Value2);
-    false -> case is_list(Value1) andalso is_list(Value2) of
-               true  -> compare_lists(Value1, Value2);
-               false -> Value1 =:= Value2
-             end
-  end.
-
-%% @private
-compare_lists(Value1, Value2) ->
-  case length(Value1) =:= length(Value2) of
-    true  -> compare_elements(Value1, Value2);
-    false -> false
-  end.
-
-%% @private
-compare_elements(Value1, Value2) ->
-  lists:all( fun({Element1, Element2}) ->
-                 is_equal(Element1, Element2)
-             end
-           , lists:zip(Value1, Value2)
-           ).
-
-%% @private
-compare_objects(Value1, Value2) ->
-  case length(unwrap(Value1)) =:= length(unwrap(Value2)) of
-    true  -> compare_properties(Value1, Value2);
-    false -> false
-  end.
-
-%% @private
-compare_properties(Value1, Value2) ->
-  lists:all( fun({PropertyName1, PropertyValue1}) ->
-                 case get_value(PropertyName1, Value2) of
-                   ?not_found     -> false;
-                   PropertyValue2 -> is_equal(PropertyValue1, PropertyValue2)
-                 end
-             end
-           , unwrap(Value1)
-           ).
 
 %%=============================================================================
 %% Wrappers

--- a/test/prop_get_equal.erl
+++ b/test/prop_get_equal.erl
@@ -14,15 +14,9 @@ prop_get_equal() ->
 %%% Helpers %%%
 %%%%%%%%%%%%%%%
 boolean(Type) ->
-    Draft3Equal = jesse_lib:is_equal(
-        jesse_lib:normalize_and_sort(Type, 3),
-        Type,
-        3),
-    Draft4Equal = jesse_lib:is_equal(
-        jesse_lib:normalize_and_sort(Type, 4),
-        Type,
-        4),
-    Draft3Equal and Draft4Equal.
+    jesse_lib:is_equal(
+        jesse_lib:normalize_and_sort(Type),
+        Type).
 
 %%%%%%%%%%%%%%%%%%
 %%% Generators %%%

--- a/test/prop_get_equal.erl
+++ b/test/prop_get_equal.erl
@@ -1,0 +1,30 @@
+-module(prop_get_equal).
+-include_lib("proper/include/proper.hrl").
+
+%%%%%%%%%%%%%%%%%%
+%%% Properties %%%
+%%%%%%%%%%%%%%%%%%
+prop_get_equal() ->
+    ?FORALL(Type, resize(10, json_list()),
+        begin
+            boolean(Type)
+        end).
+
+%%%%%%%%%%%%%%%
+%%% Helpers %%%
+%%%%%%%%%%%%%%%
+boolean(Type) ->
+    Draft3Equal = jesse_lib:is_equal(
+        jesse_lib:normalize_and_sort(Type, 3),
+        Type,
+        3),
+    Draft4Equal = jesse_lib:is_equal(
+        jesse_lib:normalize_and_sort(Type, 4),
+        Type,
+        4),
+    Draft3Equal and Draft4Equal.
+
+%%%%%%%%%%%%%%%%%%
+%%% Generators %%%
+%%%%%%%%%%%%%%%%%%
+json_list() -> list(proper_json:json()).

--- a/test/proper_json.erl
+++ b/test/proper_json.erl
@@ -1,0 +1,49 @@
+-module(proper_json).
+
+-export([json/0, json/1]).
+
+-include_lib("proper/include/proper.hrl").
+
+json() ->
+  ?SIZED(Size, json(Size)).
+
+
+json(0) ->
+  j_literal();
+json(Size) ->
+  ?LAZY(proper_types:frequency(
+          [{60, j_literal()},
+           {20, j_array(Size)},
+           {20, j_object(Size)}])).
+
+j_object(0) ->
+  #{};
+j_object(Size) ->
+  ?LET(KV,
+       proper_types:list({j_string(), json(Size div 2)}),
+       maps:from_list(KV)).
+
+j_array(0) ->
+  [];
+j_array(Size) ->
+  proper_types:list(json(Size div 2)).
+
+j_string() ->
+  %% proper_unicode:utf8().
+  ?LET(Str,
+       proper_types:non_empty(chars()),
+       list_to_binary(Str)).
+
+j_literal() ->
+    proper_types:oneof(
+      [j_string(),
+       proper_types:integer(),
+       proper_types:float(),
+       proper_types:boolean(),
+       null]).
+
+chars() ->
+  proper_types:list(
+    proper_types:oneof(lists:seq($a, $z) ++
+                         lists:seq($A, $Z) ++
+                         lists:seq($0, $9))).


### PR DESCRIPTION
The ideas behind the changes are the following:
- is_equal is moved to jesse_lib and a parameter is added so that it behaves different for draft 3 and for draft 4. This saves from repeating many lines of code that are equal and makes it much more easier to spot the change between the two behaviors.
- A module for property based testing is added. The intention is only to verify that "normalization" produces objects that are equal in terms of the is_equal function.  Maybe this is not the best way to check if normalization works, please comment.
- Normalization was also fixed in order to take into account the difference between draft 3 and draft 4 comparisons. I.e. draft 4 all numeric variables with same value should be equal, using "==", instead of "=:=".
- During normalization, JSON objects are tagged with the "struct" atom in order to be able to tell the difference between an empty object and an empty list or set.
- The Erlang sets version {version, 2} is only used if running on OTP 24 or higher.