### PR TITLE
FIX SCP-1707: Align with upstream project fixing for big integers

### DIFF
--- a/src/jesse_schema_validator.hrl
+++ b/src/jesse_schema_validator.hrl
@@ -34,9 +34,12 @@
   %% OTP 24 or higher
     -define(SET_FROM_LIST(List), sets:from_list(List, [{version, 2}])).
   -else.
-  %% OTP 23 or lower.
+  %% OTP 23, 22 or 21.
     -define(SET_FROM_LIST(List), sets:from_list(List)).
   -endif.
+-else.
+  %% OTP 20 or lower.
+  -define(SET_FROM_LIST(List), sets:from_list(List)).
 -endif.
 
 %% Constant definitions for Json schema keywords

--- a/test/JSON-Schema-Test-Suite-extra/draft3/uniqueItemsExtra.json
+++ b/test/JSON-Schema-Test-Suite-extra/draft3/uniqueItemsExtra.json
@@ -1,0 +1,23 @@
+[
+    {
+        "description": "uniqueItems extra validation",
+        "schema": {"uniqueItems": true},
+        "tests": [
+            {
+                "description": "big integers are compared correctly",
+                "data": [123456789012345678901234567890, 123456789012345678901234567891],
+                "valid": true
+            },
+            {
+                "description": "compare all elements within object, extra",
+                "data": [{"a": {"a": 1, "b": 2}}, {"a": {"b":2, "a": 1}}],
+                "valid": false
+            },
+            {
+                "description": "numbers are unique if mathematically unequal, extra",
+                "data": [1.0, 1],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/JSON-Schema-Test-Suite-extra/draft4/uniqueItemsExtra.json
+++ b/test/JSON-Schema-Test-Suite-extra/draft4/uniqueItemsExtra.json
@@ -1,0 +1,23 @@
+[
+    {
+        "description": "uniqueItems extra validation",
+        "schema": {"uniqueItems": true},
+        "tests": [
+            {
+                "description": "big integers are compared correctly",
+                "data": [123456789012345678901234567890, 123456789012345678901234567891],
+                "valid": true
+            },
+            {
+                "description": "compare all elements within object, extra",
+                "data": [{"a": {"a": 1, "b": 2}}, {"a": {"b":2, "a": 1}}],
+                "valid": false
+            },
+            {
+                "description": "numbers are unique if mathematically unequal, extra",
+                "data": [1.0, 1],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/jesse_tests_draft3_SUITE.erl
+++ b/test/jesse_tests_draft3_SUITE.erl
@@ -144,3 +144,6 @@ remoteRefExtra(Config) ->
 
 unicodePatternProperties(Config) ->
   do_test("unicodePatternProperties", Config).
+
+uniqueItemsExtra(Config) ->
+  do_test("uniqueItemsExtra", Config).

--- a/test/jesse_tests_draft4_SUITE.erl
+++ b/test/jesse_tests_draft4_SUITE.erl
@@ -177,3 +177,6 @@ ipv4Format(Config) ->
 
 ipv6Format(Config) ->
   do_test("ipv6Format", Config).
+
+uniqueItemsExtra(Config) ->
+  do_test("uniqueItemsExtra", Config).


### PR DESCRIPTION
These changes align with project https://github.com/for-GET/jesse  .

Changes ensure that big integers are considered correctly when comparing unique items in arrays, fix compatibility with older OTP versions and use map format as normalization when searching for unique items.